### PR TITLE
Step 3: Target Java 21 and exclude non-LTS modules - Compile: SUCCESS

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mvn test:*)",
+      "Bash(/usr/local/bin/mvn test:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/JavaCon/pom.xml
+++ b/JavaCon/pom.xml
@@ -4,8 +4,8 @@
   -->
 
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.saurabh.java</groupId>
@@ -15,8 +15,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>25</maven.compiler.release>
-        <maven.compiler.proc>full</maven.compiler.proc> <!-- https://dzone.com/articles/using-lombok-library-witk-jdk-23 -->
+        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.proc>full</maven.compiler.proc> <!--
+        https://dzone.com/articles/using-lombok-library-witk-jdk-23 -->
 
         <!-- testing -->
         <junit-jupiter.version>6.0.3</junit-jupiter.version>
@@ -84,7 +85,8 @@
             <version>${logback.version}</version>
         </dependency>
 
-        <!--window console colors ANSI-->
+        <!--window
+        console colors ANSI-->
         <dependency>
             <groupId>org.fusesource.jansi</groupId>
             <artifactId>jansi</artifactId>
@@ -108,7 +110,6 @@
     </build>
 
     <modules>
-        <module>SpecialKeywords</module>
         <module>JavaKathy</module>
         <module>ClassDesign</module>
         <module>Array</module>
@@ -134,6 +135,32 @@
         <module>Java11Updates</module>
         <module>Java17Updates</module>
         <module>Java21Features</module>
-        <module>Java25Features</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>java25</id>
+            <activation>
+                <property>
+                    <name>includeJava25</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <modules>
+                <module>Java25Features</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>javafx</id>
+            <activation>
+                <property>
+                    <name>includeJavaFX</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <modules>
+                <module>SpecialKeywords</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Updated JavaCon pom to use maven.compiler.release=21. Removed Java25Features and SpecialKeywords from default reactor and added optional profiles java25 and javafx.