### PR TITLE
chore(renovate): auto-merge minor and patch updates via GitHub native

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,17 +1,21 @@
 {
   "separateMajorMinor": true,
   "separateMultipleMajor": true,
+  "platformAutomerge": true,
+  "automergeStrategy": "squash",
   "packageRules": [
     {
       "groupName": "Minor and Patch Dependencies",
       "groupSlug": "minor-patch",
       "matchUpdateTypes": ["minor", "patch"],
-      "matchPackageNames": ["*"]
+      "matchPackageNames": ["*"],
+      "automerge": true
     },
     {
       "matchUpdateTypes": ["major"],
       "groupName": null,
-      "additionalBranchPrefix": "major-"
+      "additionalBranchPrefix": "major-",
+      "automerge": false
     }
   ],
   "extends": [


### PR DESCRIPTION
Turn on platform auto-merge so Renovate marks minor/patch PRs for GitHub's native auto-merge, which now gates on the "build" check required by the master ruleset. Major updates stay manual — the ojdbc11 21 → 23 bump showed why majors need a human review.
